### PR TITLE
Improve responsive CSS and clean markup

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -43,7 +43,6 @@
   <div class="container">
     <h1 class="text-center mb-4">Blog Articles</h1>
     <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4" id="blog-posts"></div>
-    <div class="row" id="blog-posts"></div>
   </div>
 </section>
 <footer class="footer text-center">

--- a/css/style.css
+++ b/css/style.css
@@ -113,7 +113,7 @@ a:hover {
   box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.15);
 }
 
-.lead2 {
+.lead-text {
   font-size: 1.1rem;
   line-height: 1.6;
   color: #333;
@@ -699,21 +699,6 @@ footer {
   justify-content: center;
   margin-bottom: 30px;
 }
-
-.card {
-  border-radius: 10px;
-  overflow: hidden;
-  transition: transform 0.3s ease;
-  width: 100%;
-  max-width: 400px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-}
-
-.card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 8px 15px rgba(0, 0, 0, 0.2);
-}
-
 .card-img-top {
   width: 100%;
   height: 200px;
@@ -734,6 +719,7 @@ footer {
   font-size: 1rem;
   color: #555;
 }
+
 
 .blog-date {
   font-size: 0.9rem;
@@ -815,6 +801,7 @@ footer {
   height: 5px;
   background: #3a86ff;
   z-index: 2000;
+}
 
 /* Interactive feedback buttons */
 .interactive-feedback {
@@ -836,6 +823,14 @@ footer {
 
 .interactive-feedback button:focus {
   outline: 2px solid #0058d4;
+}
 
+@media (max-width: 576px) {
+  #about, #Exchange, #portfolio, #blog, .paralax-mf {
+    max-width: 95%;
+    padding-left: 10px;
+    padding-right: 10px;
   }
+  #about { padding: 3rem 0; }
+  #blog { padding: 3rem 0; }
 }

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
               <img src="img/intro-bg.jpg" alt="Diego Badelli" class="about-img" loading="lazy">
             </div>
             <div class="about-right">
-              <p class="lead2">
+              <p class="lead-text">
                 I am a multidisciplinary engineer with solid experience in product development, project management,
                 process optimization, and R&D. I have worked in global environments, collaborating with diverse teams to
                 implement practical solutions aligned with organizational goals.
@@ -204,7 +204,7 @@
               <img src="img/testimonial-2.jpg" class="img-fluid rounded shadow" alt="Diego Badelli Exchange" loading="lazy">
             </div>
             <div class="col-lg-6" data-aos="fade-up">
-              <p class="lead2">
+              <p class="lead-text">
                 During my academic exchange between 2012 and 2013, I deepened my knowledge of electrical engineering at
                 Université de Technologie de Belfort-Montbeliard in France. This experience provided me with a global
                 perspective and solidified my passion for innovation and problem-solving.


### PR DESCRIPTION
## Summary
- cleaned duplicated card styles and fixed CSS syntax
- renamed `.lead2` class to `.lead-text`
- improved mobile margins
- fixed duplicate blog posts container

## Testing
- `pytest` *(no tests found)*
- `npm test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488c6b2fcc832bb61fcd93f1518440